### PR TITLE
Feat: 조건에 맞는 페이지 보여주기

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,14 +1,15 @@
-import React, { Dispatch, SetStateAction } from 'react'
+import React, { Dispatch, SetStateAction, MouseEvent } from 'react'
 import styled from 'styled-components'
 import { AiFillStar, AiOutlineStar } from 'react-icons/ai'
-import { IItems } from './Search'
+import { ICard } from 'types/interface'
 import { VscIssues } from 'react-icons/vsc'
 
-export interface CardProps {
-  data: IItems
+interface CardProps {
+  data: ICard
   starred: boolean
-  storageState: IItems[]
-  setStorageState: Dispatch<SetStateAction<IItems[]>>
+  storageState: ICard[]
+  setStorageState: Dispatch<SetStateAction<ICard[]>>
+  onClick?: (e: MouseEvent<HTMLDivElement>) => void
 }
 
 export default function Card({
@@ -16,8 +17,10 @@ export default function Card({
   starred,
   storageState,
   setStorageState,
+  onClick,
 }: CardProps) {
-  const handleStar = () => {
+  const handleStar = (e: MouseEvent<HTMLOrSVGElement>) => {
+    e.stopPropagation()
     const index = storageState.findIndex(
       (item) => item.full_name === data.full_name
     )
@@ -43,7 +46,7 @@ export default function Card({
     }
   }
   return (
-    <CardWrap>
+    <CardWrap onClick={onClick}>
       <CardItem>
         <div
           style={{

--- a/src/components/PlusButton.tsx
+++ b/src/components/PlusButton.tsx
@@ -25,8 +25,8 @@ const ImageWrapper = styled.div`
 
 export default function PlusButton() {
   return (
-    <a>
+    <button>
       <ImageWrapper>+</ImageWrapper>
-    </a>
+    </button>
   )
 }

--- a/src/components/Repositories.tsx
+++ b/src/components/Repositories.tsx
@@ -1,22 +1,24 @@
-import React, { Dispatch, SetStateAction } from 'react'
+import React, { Dispatch, SetStateAction, MouseEvent } from 'react'
 import styled from 'styled-components'
 import AddButton from '../assets/addButton.svg'
 import Card from './Card'
-import { IItems } from './Search'
+import { ClassesObject, ICard } from 'types/interface'
 
 interface RepositoriesProps {
-  setViewSide: Dispatch<SetStateAction<boolean>>
-  storageState: IItems[]
-  setStorageState: Dispatch<SetStateAction<IItems[]>>
+  setClasses: Dispatch<SetStateAction<ClassesObject>>
+  storageState: ICard[]
+  setStorageState: Dispatch<SetStateAction<ICard[]>>
+  setClickedRepo: Dispatch<SetStateAction<string>>
 }
 
 const Repositories = ({
-  setViewSide,
+  setClasses,
   storageState,
   setStorageState,
+  setClickedRepo,
 }: RepositoriesProps) => {
   const showCards = () => {
-    return storageState?.map((data: any) => {
+    return storageState?.map((data) => {
       const starred =
         storageState.findIndex((item) => item.full_name === data.full_name) >= 0
       return (
@@ -26,9 +28,41 @@ const Repositories = ({
           data={data}
           storageState={storageState}
           setStorageState={setStorageState}
+          onClick={() => handleCardClick(data.full_name)}
         />
       )
     })
+  }
+
+  const handleCardClick = (full_name: string) => {
+    setClickedRepo(full_name)
+    const width = window.innerWidth
+    if (width > 768) {
+      // desktop
+      setClasses((prev) => ({ ...prev, toShow: 'issues' }))
+    } else {
+      // mobile
+      setClasses((prev) => ({
+        ...prev,
+        toShow: 'issues',
+        sideContainer: 'slide-in',
+      }))
+    }
+  }
+
+  const handleAddClick = (e: MouseEvent<HTMLDivElement>) => {
+    const width = window.innerWidth
+    if (width > 768) {
+      // desktop
+      setClasses((prev) => ({ ...prev, toShow: 'search' }))
+    } else {
+      // mobile
+      setClasses((prev) => ({
+        ...prev,
+        toShow: 'search',
+        sideContainer: 'slide-in',
+      }))
+    }
   }
 
   return (
@@ -46,15 +80,10 @@ const Repositories = ({
       <AddBtn
         src={AddButton}
         alt="Move to search page"
-        onClick={() => setViewSide(true)}
+        onClick={handleAddClick}
       />
     </RepositoryWrapper>
   )
-}
-
-const color = {
-  primary: '#112155',
-  secondary: '#6C84EE',
 }
 
 const RepositoryWrapper = styled.section`
@@ -90,27 +119,6 @@ const SavedRepo = styled.div`
   @media (max-width: 768px) {
     display: grid;
     grid-template-columns: 1fr;
-  }
-`
-
-const Title = styled.img`
-  display: block;
-`
-
-const Subtitle = styled.h3`
-  margin: 16px 0;
-`
-
-const Dummy = styled.article`
-  width: 100%;
-  height: 140px;
-  margin: 16px 0;
-  border: 2px solid black;
-  border-radius: 24px;
-  transition: background-color 0.2s ease-out;
-
-  :hover {
-    background-color: ${color.secondary};
   }
 `
 

--- a/src/types/interface.d.ts
+++ b/src/types/interface.d.ts
@@ -1,0 +1,12 @@
+export interface ClassesObject {
+  sideContainer: string
+  toShow: string
+  desktop: string
+}
+
+export interface ICard {
+  full_name: string
+  avatar_url: string
+  stargazers_count: number
+  open_issues: number
+}


### PR DESCRIPTION
#24
- 전반적인 인터페이스 이름 통일
- any 타입으로 선언된 부분 모두 수정
- 뒤로 가기 버튼이 데스크톱 레이아웃에선 사라지도록 수정
- interface.d.ts: export한 인터페이스 모음
- Issues.tsx: 이슈 아이콘이 찌그러지던 문제 해결
- Issues.tsx: repo가 바뀌어도 새로 불러오지 않던 문제 해결
- Issues.tsx: 마운트 해제될 때 내용 초기화
- Card.tsx: 리스트 아이템을 누르면 해당하는 이슈 페이지로 이동
- App.tsx: 반응형 레이아웃 전환이 매끄럽도록 수정
- Repositories.tsx: 카드나 추가 버튼을 누르면 맞는 페이지가 열리도록 수정
- Search.tsx: 마운트 해제될 때 검색어 및 결과 초기화